### PR TITLE
Withdrawal hint accuracy

### DIFF
--- a/src/pages/PortalPoolPage/dialogs/WithdrawDialog.tsx
+++ b/src/pages/PortalPoolPage/dialogs/WithdrawDialog.tsx
@@ -236,15 +236,19 @@ export function WithdrawButton({ poolId }: WithdrawButtonProps) {
   const handleOpen = useCallback(() => setDialogOpen(true), []);
   const handleClose = useCallback(() => setDialogOpen(false), []);
 
+  const tooltipTitle = useMemo(() => {
+    if (pool?.phase === 'collecting') {
+      return WITHDRAW_DIALOG_TEXTS.tooltips.collecting;
+    }
+    if (!hasBalance) {
+      return WITHDRAW_DIALOG_TEXTS.tooltips.nothingToWithdraw;
+    }
+    return '';
+  }, [pool?.phase, hasBalance]);
+
   return (
     <>
-      <Tooltip
-        title={
-          pool?.phase === 'collecting'
-            ? WITHDRAW_DIALOG_TEXTS.tooltips.collecting
-            : WITHDRAW_DIALOG_TEXTS.tooltips.nothingToWithdraw
-        }
-      >
+      <Tooltip title={tooltipTitle}>
         <span>
           <Button
             variant="outlined"


### PR DESCRIPTION
Corrects the "Nothing to withdraw" tooltip logic on the Withdraw button.

The tooltip previously displayed "Nothing to withdraw" incorrectly when a user had a balance or when the pool was still in the "collecting" phase. This change ensures the tooltip accurately reflects the withdrawal status.

---
Linear Issue: [SDKTL-227](https://linear.app/sqd-ai/issue/SDKTL-227/nothing-to-withdraw-hint-always-shows)

<a href="https://cursor.com/background-agent?bcId=bc-ee3361c3-0af5-4174-82d3-97bbad4921c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee3361c3-0af5-4174-82d3-97bbad4921c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves tooltip accuracy on the `WITHDRAW` button in `WithdrawDialog.tsx`.
> 
> - Memoizes `tooltipTitle` to conditionally show `collecting` text during the collecting phase, `nothingToWithdraw` only when the user has zero balance, and no tooltip otherwise
> - Leaves button enable/disable behavior unchanged (`disabled` when no balance or during collecting)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecc31e9e26c566fe0a488d980883e9de6572fa49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->