### PR TITLE
Withdrawal button update

### DIFF
--- a/src/pages/PortalPoolPage/PendingWithdrawals.tsx
+++ b/src/pages/PortalPoolPage/PendingWithdrawals.tsx
@@ -28,6 +28,7 @@ import { Card } from '@components/Card';
 import { HelpTooltip } from '@components/HelpTooltip';
 import { DashboardTable, NoItems } from '@components/Table';
 import { useCountdown } from '@hooks/useCountdown';
+import { useTicker } from '@hooks/useTicker';
 import { useExplorer } from '@hooks/useExplorer';
 import { addressFormatter, tokenFormatter } from '@lib/formatters/formatters';
 import { useContracts } from '@hooks/network/useContracts';
@@ -52,10 +53,19 @@ function WithdrawalRow({
   isClaiming: boolean;
 }) {
   const { SQD_TOKEN } = useContracts();
-  const isReady = withdrawal.estimatedCompletionAt.getTime() < Date.now();
+  const [currentTime, setCurrentTime] = useState(Date.now());
   const timeLeft = useCountdown({
     timestamp: withdrawal.estimatedCompletionAt,
   });
+
+  // Update current time every second to recalculate isReady
+  const updateTime = useCallback(() => {
+    setCurrentTime(Date.now());
+  }, []);
+
+  useTicker(updateTime, 1000);
+
+  const isReady = withdrawal.estimatedCompletionAt.getTime() < currentTime;
 
   return (
     <TableRow>


### PR DESCRIPTION
Make the withdrawal button automatically update when the countdown reaches 0.

Previously, the `isReady` variable in the `WithdrawalRow` component was calculated only once during render. This meant that even after the countdown timer reached zero, the button remained disabled until the page was manually refreshed. This PR introduces a reactive `currentTime` state, updated every second using `useTicker`, to ensure `isReady` is re-evaluated dynamically, allowing the button to enable automatically.

---
Linear Issue: [SDKTL-211](https://linear.app/sqd-ai/issue/SDKTL-211/when-withdrawal-timeout-reaches-0-nothing-happens)

<a href="https://cursor.com/background-agent?bcId=bc-ebb7ea58-4d2c-4162-8acc-692778260090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ebb7ea58-4d2c-4162-8acc-692778260090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures withdrawal claim eligibility updates in real time.
> 
> - In `PendingWithdrawals.tsx`, `WithdrawalRow` now tracks `currentTime` and uses `useTicker` to update it every second, recalculating `isReady`
> - The CLAIM button automatically enables when `estimatedCompletionAt` passes, removing the need for manual refresh
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fe5616156031eb34e4047a81f0eea1a788128ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->