### PR TITLE
feat: read claimable rewards balance from RPC instead of indexer

### DIFF
--- a/packages/client/src/pages/AssetsPage/Assets.tsx
+++ b/packages/client/src/pages/AssetsPage/Assets.tsx
@@ -136,7 +136,7 @@ function useTokenBalances(
           'Claimable',
           theme.palette.info.main,
           theme.palette.info.main,
-          'Earned but not yet claimed token rewards, aggregated across all workers and delegations',
+          'Earned but not yet claimed token rewards, aggregated across all workers and delegations. Read directly from the rewards distribution contract on-chain, so it always matches what `Claim` will transfer. Note: per-worker and per-delegation reward figures shown elsewhere come from the indexer and may briefly diverge from this on-chain total.',
         ),
         value: BigNumber(serverBalances?.claimable || 0),
       },
@@ -216,10 +216,7 @@ export function MyAssets() {
     return [...items].sort((a, b) => b.value.comparedTo(a.value) ?? 0);
   }, [balances, showDemoPortals]);
 
-  const pieBalances = useMemo(
-    () => balances.filter(b => b.name !== 'Claimable'),
-    [balances],
-  );
+  const pieBalances = useMemo(() => balances.filter(b => b.name !== 'Claimable'), [balances]);
 
   return (
     <Grid container spacing={2}>

--- a/packages/client/src/pages/AssetsPage/ClaimButton.tsx
+++ b/packages/client/src/pages/AssetsPage/ClaimButton.tsx
@@ -1,35 +1,26 @@
 import { useMemo, useState } from 'react';
 
 import { TollOutlined } from '@mui/icons-material';
-import { Box, Button, TableBody, TableCell, TableRow } from '@mui/material';
+import { Button } from '@mui/material';
 import { useFormik } from 'formik';
 import { useAccount, useClient } from 'wagmi';
 import * as yup from 'yup';
 
 import { rewardTreasuryAbi, useReadRouterRewardTreasury } from '@api/contracts';
 import { useWriteSQDTransaction } from '@api/contracts/useWriteTransaction';
-import { AccountType, SourceWalletWithBalance, Worker } from '@api/subsquid-network-squid';
+import { AccountType, SourceWalletWithBalance } from '@api/subsquid-network-squid';
 import { ContractCallDialog } from '@components/ContractCallDialog';
 import { Form, FormRow, FormikSelect } from '@components/Form';
 import { Loader } from '@components/Loader';
 import { SourceWalletOption } from '@components/SourceWallet';
-import { TableList } from '@components/Table/TableList.tsx';
-import { WorkerName } from '@components/Worker';
 import { useContracts } from '@hooks/network/useContracts';
 import { useSquidHeight } from '@hooks/useSquidNetworkHeightHooks';
-import { tokenFormatter } from '@lib/formatters/formatters';
-import { fromSqd } from '@lib/network/utils';
 
 export const claimSchema = yup.object({
   source: yup.string().label('Source').trim().required('Source is required'),
 });
 
-export type SourceWalletWithClaims = SourceWalletWithBalance & {
-  claims: (Pick<Worker, 'id' | 'peerId' | 'name'> & {
-    type: 'worker' | 'delegation';
-    claimableReward: string;
-  })[];
-};
+export type SourceWalletWithClaims = SourceWalletWithBalance;
 
 export function ClaimButton({
   sources,
@@ -157,35 +148,6 @@ export function ClaimDialog({
               }}
             />
           </FormRow>
-
-          <Box
-            sx={{
-              maxHeight: '50vh',
-              overflow: 'auto',
-            }}
-          >
-            <TableList>
-              <TableBody>
-                {sources
-                  .find(s => s.id === formik.values.source)
-                  ?.claims.map(w => {
-                    return (
-                      <TableRow key={w.id}>
-                        <TableCell>
-                          <WorkerName worker={w} />
-                        </TableCell>
-                        <TableCell>
-                          {w.type === 'worker' ? 'Worker reward' : 'Delegation reward'}
-                        </TableCell>
-                        <TableCell align="right">
-                          {tokenFormatter(fromSqd(w.claimableReward), contracts.SQD_TOKEN)}
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-              </TableBody>
-            </TableList>
-          </Box>
         </Form>
       )}
     </ContractCallDialog>

--- a/packages/client/src/pages/DelegationsPage/DelegationsPage.tsx
+++ b/packages/client/src/pages/DelegationsPage/DelegationsPage.tsx
@@ -78,6 +78,7 @@ export function MyDelegations() {
                 sort={WorkerSortBy.MyDelegationReward}
                 query={query}
                 setQuery={setQuery}
+                help="Per-delegation reward totals come from the indexer and may be slightly out of date. The aggregated Claimable balance shown on the Assets page is read directly from the on-chain rewards contract and is always accurate."
               >
                 Total reward
               </SortableHeaderCell>

--- a/packages/client/src/pages/WorkerPage/General.tsx
+++ b/packages/client/src/pages/WorkerPage/General.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 
 import { useWorkerByPeerId } from '@api/subsquid-network-squid';
 import { Card } from '@components/Card';
+import { HelpTooltip } from '@components/HelpTooltip';
 import { Loader } from '@components/Loader';
 import { NotFound } from '@components/NotFound';
 import { Property, PropertyList } from '@components/Property';
@@ -85,7 +86,11 @@ export function WorkerGeneral() {
                 value={worker.apr != null ? percentFormatter(worker.apr) : '-'}
               />
               <Property
-                label="Total reward"
+                label={
+                  <HelpTooltip title="Per-worker reward totals come from the indexer and may be slightly out of date. The aggregated Claimable balance shown on the Assets page is read directly from the on-chain rewards contract and is always accurate.">
+                    Total reward
+                  </HelpTooltip>
+                }
                 value={tokenFormatter(fromSqd(worker.totalReward), SQD_TOKEN)}
               />
             </PropertyList>

--- a/packages/client/src/pages/WorkersPage/WorkersPage.tsx
+++ b/packages/client/src/pages/WorkersPage/WorkersPage.tsx
@@ -97,6 +97,7 @@ export function MyWorkers() {
                   sort={WorkerSortBy.WorkerReward}
                   query={query}
                   setQuery={setQuery}
+                  help="Per-worker reward totals come from the indexer and may be slightly out of date. The aggregated Claimable balance shown on the Assets page is read directly from the on-chain rewards contract and is always accurate."
                 >
                   Total reward
                 </SortableHeaderCell>

--- a/packages/common/src/abi/index.ts
+++ b/packages/common/src/abi/index.ts
@@ -6,6 +6,7 @@ export { networkControllerAbi } from './networkController';
 export { portalPoolAbi } from './portalPool';
 export { portalPoolFactoryAbi } from './portalPoolFactory';
 export { portalRegistryAbi } from './portalRegistry';
+export { rewardDistributionAbi } from './rewardDistribution';
 export { rewardTreasuryAbi } from './rewardTreasury';
 export { routerAbi } from './router';
 export { softCapAbi } from './softCap';

--- a/packages/common/src/abi/rewardDistribution.ts
+++ b/packages/common/src/abi/rewardDistribution.ts
@@ -1,0 +1,40 @@
+export const rewardDistributionAbi = [
+  {
+    type: 'function',
+    name: 'claimable',
+    inputs: [
+      {
+        name: 'who',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'reward',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'claim',
+    inputs: [
+      {
+        name: 'who',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'reward',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+  },
+] as const;

--- a/packages/server/src/routers/account.ts
+++ b/packages/server/src/routers/account.ts
@@ -23,6 +23,7 @@ import {
 } from '../generated/workers-squid/graphql.js';
 import { resolveAccounts } from '../services/accounts.js';
 import { queryGatewaysSquid, queryTokenSquid, queryWorkersSquid } from '../services/graphql.js';
+import { readClaimableRewards } from '../services/rewards.js';
 import { publicProcedure, router } from '../trpc.js';
 import { evmAddressSchema } from '../validation.js';
 
@@ -77,12 +78,14 @@ export const accountRouter = router({
 
       const ownerIds = accounts.map(a => a.id);
 
-      const [workersData, delegationsData, stakesData, poolProvidersData] = await Promise.all([
-        queryWorkersSquid<WorkersByOwnerQuery>(WorkersByOwnerDocument, { ownerIds }),
-        queryWorkersSquid<DelegationsByOwnerQuery>(DelegationsByOwnerDocument, { ownerIds }),
-        queryGatewaysSquid<GatewayStakesByOwnerQuery>(GatewayStakesByOwnerDocument, { ownerIds }),
-        queryGatewaysSquid<PoolProvidersByOwnerQuery>(PoolProvidersByOwnerDocument, { ownerIds }),
-      ]);
+      const [workersData, delegationsData, stakesData, poolProvidersData, claimableByAddress] =
+        await Promise.all([
+          queryWorkersSquid<WorkersByOwnerQuery>(WorkersByOwnerDocument, { ownerIds }),
+          queryWorkersSquid<DelegationsByOwnerQuery>(DelegationsByOwnerDocument, { ownerIds }),
+          queryGatewaysSquid<GatewayStakesByOwnerQuery>(GatewayStakesByOwnerDocument, { ownerIds }),
+          queryGatewaysSquid<PoolProvidersByOwnerQuery>(PoolProvidersByOwnerDocument, { ownerIds }),
+          readClaimableRewards(ownerIds),
+        ]);
 
       const workersByOwner = new Map<string, WorkersByOwnerQuery['workers']>();
       for (const w of workersData.workers) {
@@ -132,15 +135,11 @@ export const accountRouter = router({
         const accountDelegations = delegationsByOwner.get(account.id) ?? [];
         for (const delegation of accountDelegations) {
           balances.delegated = BigNumber(balances.delegated).plus(delegation.deposit).toFixed();
-          balances.claimable = BigNumber(balances.claimable)
-            .plus(delegation.claimableReward)
-            .toFixed();
         }
 
         const accountWorkers = workersByOwner.get(account.id) ?? [];
         for (const worker of accountWorkers) {
           balances.bonded = BigNumber(balances.bonded).plus(worker.bond).toFixed();
-          balances.claimable = BigNumber(balances.claimable).plus(worker.claimableReward).toFixed();
         }
 
         const accountStakes = stakesByOwner.get(account.id) ?? [];
@@ -153,47 +152,19 @@ export const accountRouter = router({
           balances.portalPool = BigNumber(balances.portalPool).plus(provider.deposited).toFixed();
         }
 
-        const claims: Array<{
-          id: string;
-          peerId: string;
-          name: string | null;
-          claimableReward: string;
-          type: 'worker' | 'delegation';
-        }> = [];
-
-        for (const delegation of accountDelegations) {
-          if (delegation.claimableReward === '0') continue;
-          claims.push({
-            id: delegation.worker.id,
-            peerId: delegation.worker.peerId,
-            name: delegation.worker.name ?? null,
-            claimableReward: delegation.claimableReward,
-            type: 'delegation',
-          });
-        }
-
-        for (const worker of accountWorkers) {
-          if (worker.claimableReward === '0') continue;
-          claims.push({
-            id: worker.id,
-            peerId: worker.peerId,
-            name: worker.name ?? null,
-            claimableReward: worker.claimableReward,
-            type: 'worker',
-          });
-        }
-
-        claims.sort((a, b) => BigNumber(b.claimableReward).comparedTo(a.claimableReward) ?? 0);
-
-        const totalClaimableBalance = claims
-          .reduce((total, claim) => total.plus(claim.claimableReward), BigNumber(0))
-          .toFixed();
+        // Claimable totals are read from the on-chain
+        // DistributedRewardsDistribution contract (see packages/common `rewardDistributionAbi`)
+        // instead of from the Squid indexer, so the UI reflects the actual
+        // amount that `claimFor` will transfer even when the indexer lags.
+        const claimableOnChain = (
+          claimableByAddress.get(account.id.toLowerCase()) ?? 0n
+        ).toString();
+        balances.claimable = BigNumber(balances.claimable).plus(claimableOnChain).toFixed();
 
         return {
           id: account.id,
           type: account.type,
-          balance: totalClaimableBalance,
-          claims,
+          balance: claimableOnChain,
         };
       });
 

--- a/packages/server/src/services/rewards.ts
+++ b/packages/server/src/services/rewards.ts
@@ -1,0 +1,39 @@
+import { rewardDistributionAbi } from '@subsquid/common';
+import type { Address } from 'viem';
+
+import { getContractAddresses } from '../env.js';
+import { getPublicClient } from './blockchain.js';
+
+/**
+ * Reads the total claimable reward amount (worker + delegation rewards combined)
+ * for a set of addresses directly from the DistributedRewardsDistribution
+ * contract via RPC. This is preferred over querying the Squid GraphQL indexer
+ * because the on-chain value is the source of truth that the `claimFor` call
+ * will actually settle against, so the UI stays in sync with the chain even
+ * when the indexer is lagging.
+ */
+export async function readClaimableRewards(addresses: string[]): Promise<Map<string, bigint>> {
+  const result = new Map<string, bigint>();
+  if (addresses.length === 0) return result;
+
+  const publicClient = getPublicClient();
+  const { REWARD_DISTRIBUTION } = getContractAddresses();
+  const contract: Address = REWARD_DISTRIBUTION;
+
+  const calls = addresses.map(address => ({
+    abi: rewardDistributionAbi,
+    address: contract,
+    functionName: 'claimable' as const,
+    args: [address as Address],
+  }));
+
+  const results = await publicClient.multicall({ contracts: calls, allowFailure: true });
+
+  for (let i = 0; i < addresses.length; i++) {
+    const res = results[i];
+    const value = res.status === 'success' ? (res.result as bigint) : 0n;
+    result.set(addresses[i].toLowerCase(), value);
+  }
+
+  return result;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reads the "Claimable" rewards balance directly from the on-chain `DistributedRewardsDistribution` contract via RPC (viem multicall) instead of aggregating per-worker / per-delegation `claimableReward` values from the Squid GraphQL indexer.

This keeps the UI's _Claimable_ balance and the per-source total shown in the Claim dialog in sync with the amount that `RewardTreasury.claimFor` will actually transfer, even when the indexer is lagging the chain.

## Changes

- `packages/common/src/abi/rewardDistribution.ts`: new `rewardDistributionAbi` with the `claimable(address) view` and `claim(address)` functions from the `IRewardsDistribution` interface.
- `packages/common/src/abi/index.ts`: export the new ABI.
- `packages/server/src/services/rewards.ts`: new `readClaimableRewards(addresses)` helper that batches `claimable` calls to the deployed `REWARD_DISTRIBUTION` contract via the existing `getPublicClient()` multicall transport.
- `packages/server/src/routers/account.ts` (`assetsSummary`): the `balances.claimable` total and each `claimableSources[].balance` now come from RPC; the indexer-derived `claimableReward` fields are no longer used for these values. The `claims` per-worker/per-delegation breakdown was removed from the response (not needed anymore).
- `packages/client/src/pages/AssetsPage/ClaimButton.tsx`: drops the per-worker claims table (since the server no longer returns `claims`). The Claim dialog still lets the user pick a source wallet and the total shown in the `SourceWalletOption` uses the RPC-derived balance.
- `packages/client/src/pages/AssetsPage/Assets.tsx`, `packages/client/src/pages/WorkersPage/WorkersPage.tsx`, `packages/client/src/pages/DelegationsPage/DelegationsPage.tsx`, `packages/client/src/pages/WorkerPage/General.tsx`: added help-tooltips noting that per-worker / per-delegation reward totals shown on those pages come from the indexer and may be slightly out of date — only the aggregated _Claimable_ balance on the Assets page is guaranteed accurate.

## Contract reference

Reference implementation used to build the ABI and service:

- https://github.com/subsquid/subsquid-network-contracts/blob/master/packages/contracts/src/DistributedRewardDistribution.sol
- https://github.com/subsquid/subsquid-network-contracts/blob/master/packages/contracts/src/interfaces/IRewardsDistribution.sol

The `claimable(address who) view returns (uint256 reward)` call internally sums `IStaking.claimable(who)` (delegation rewards) and `_claimable[workerId]` for each worker owned by `who`, so a single call per source address gives us the full claimable total.

## Notes

- Per-worker splitting of claimable rewards was intentionally **not** implemented (would require extra per-worker RPC calls or additional public getters on the contracts).
- Uses the existing `REWARD_DISTRIBUTION` address from `@subsquid/common` `CONTRACT_ADDRESSES` and the existing RPC client, so no new env vars are required.

## Verification

- `pnpm tsc` — passes
- `pnpm lint` — passes (only pre-existing warnings in unrelated files)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2cf8537-808e-42d1-8c28-137902e06adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2cf8537-808e-42d1-8c28-137902e06adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

