### PR TITLE
fix(client): correct invalid DOM nesting warnings

### DIFF
--- a/packages/client/src/components/PageTabs/PageTabs.tsx
+++ b/packages/client/src/components/PageTabs/PageTabs.tsx
@@ -111,7 +111,7 @@ export function PageTabs({
             disabled={disabled}
             data-before={title}
             label={
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Box component="span" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 {icon}
                 {title}
               </Box>

--- a/packages/client/src/components/Table/NoItems.tsx
+++ b/packages/client/src/components/Table/NoItems.tsx
@@ -35,7 +35,7 @@ export const NoItems = ({
       >
         <Stack spacing={1} direction="row" alignItems="center">
           {icon}
-          <Typography variant="body1">{children || <span>{message}</span>}</Typography>
+          {children ? children : <Typography variant="body1">{message}</Typography>}
         </Stack>
       </Box>
     </td>

--- a/packages/client/src/components/Table/PaginatedTable.tsx
+++ b/packages/client/src/components/Table/PaginatedTable.tsx
@@ -8,7 +8,6 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  Typography,
 } from '@mui/material';
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 
@@ -84,8 +83,8 @@ export function PaginatedTable<TData>({
             </TableHead>
             <TableBody>
               {showEmptyState ? (
-                <NoItems>
-                  <Typography>{emptyMessage}</Typography>
+                <NoItems message={typeof emptyMessage === 'string' ? emptyMessage : undefined}>
+                  {typeof emptyMessage !== 'string' ? emptyMessage : undefined}
                 </NoItems>
               ) : (
                 table.getRowModel().rows.map(row => (

--- a/packages/client/src/contexts/SourceContext.tsx
+++ b/packages/client/src/contexts/SourceContext.tsx
@@ -1,8 +1,9 @@
 import { ReactNode, createContext, useContext, useEffect } from 'react';
 
+import { useAccount } from 'wagmi';
+
 import { SourceWalletWithBalance, useMySources } from '@api/subsquid-network-squid';
 import { useLocalStorageState } from '@hooks/useLocalStorageState';
-import { useAccount } from 'wagmi';
 
 interface SourceContextType {
   setSelectedSourceId: (sourceId: string) => void;

--- a/packages/client/src/hooks/useMockPersonaRestore.ts
+++ b/packages/client/src/hooks/useMockPersonaRestore.ts
@@ -15,6 +15,7 @@
  * No-op in non-mock (production) builds.
  */
 import { useEffect, useRef } from 'react';
+
 import { useAccount, useConfig, useConnect } from 'wagmi';
 
 import { MOCK_PERSONA_STORAGE_KEY, isMockMode } from '../config';

--- a/packages/client/src/layouts/NetworkLayout/NetworkPageTitle.tsx
+++ b/packages/client/src/layouts/NetworkLayout/NetworkPageTitle.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, ReactNode } from 'react';
 
-import { Box, SxProps, Typography, styled } from '@mui/material';
+import { SxProps, Typography, styled } from '@mui/material';
 
 import { BackButton } from '@components/BackButton';
 
@@ -40,13 +40,13 @@ export function NetworkPageTitle({
 }>) {
   return (
     <PageTitleWrapper sx={sx}>
-      <Typography variant="h1" sx={{ lineHeight: 1 }}>
-        <div className="title">
-          <BackButton />
-          <Box color="text.primary">{title}</Box>
-          {endAdornment ? <div className="endAdornment">{endAdornment}</div> : null}
-        </div>
-      </Typography>
+      <div className="title" style={{ lineHeight: 1 }}>
+        <BackButton />
+        <Typography variant="h1" color="text.primary">
+          {title}
+        </Typography>
+        {endAdornment ? <div className="endAdornment">{endAdornment}</div> : null}
+      </div>
       {children ? <PageDescription>{children}</PageDescription> : null}
     </PageTitleWrapper>
   );

--- a/packages/client/src/layouts/NetworkLayout/PageTitle.tsx
+++ b/packages/client/src/layouts/NetworkLayout/PageTitle.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 
-import { Box, SxProps, Theme, Typography, styled } from '@mui/material';
+import { SxProps, Theme, Typography, styled } from '@mui/material';
 
 import { BackButton } from '@components/BackButton';
 
@@ -39,8 +39,8 @@ export function PageTitle({
     <PageTitleWrapper sx={sx}>
       <div className="title">
         {backButton && <BackButton path={backPath} />}
-        <Typography variant="h4" sx={{ textWrap: 'balance' }}>
-          <Box color="text.primary">{title}</Box>
+        <Typography variant="h4" color="text.primary" sx={{ textWrap: 'balance' }}>
+          {title}
         </Typography>
       </div>
       {children ? <PageDescription>{children}</PageDescription> : null}

--- a/packages/client/src/pages/DashboardPage/DashboardPage.tsx
+++ b/packages/client/src/pages/DashboardPage/DashboardPage.tsx
@@ -25,7 +25,7 @@ export function DashboardPage() {
         <Tab
           value="portal-pools"
           label={
-            <Stack direction="row" alignItems="center" spacing={0.75}>
+            <Stack component="span" direction="row" alignItems="center" spacing={0.75}>
               <span>Portal Pools</span>
               <Chip label="New" size="small" color="info" variant="outlined" />
             </Stack>

--- a/packages/client/src/pages/DashboardPage/Summary.tsx
+++ b/packages/client/src/pages/DashboardPage/Summary.tsx
@@ -19,7 +19,7 @@ import { fromSqd } from '@lib/network';
 
 export function ColumnLabel({ children, color }: PropsWithChildren<{ color?: string }>) {
   return (
-    <Typography variant="h4" mb={1} mt={1} color={color}>
+    <Typography component="div" variant="h4" mb={1} mt={1} color={color}>
       {children}
     </Typography>
   );
@@ -43,7 +43,9 @@ function OnlineInfo() {
             <span>Data</span>
             <SquaredChip
               label={
-                <Typography variant="subtitle1">{bytesFormatter(data?.storedData)}</Typography>
+                <Typography component="span" variant="subtitle1">
+                  {bytesFormatter(data?.storedData)}
+                </Typography>
               }
               color="info"
             />
@@ -68,7 +70,11 @@ function CurrentEpochEstimation({ epochEnd }: { epochEnd: number }) {
     <Stack direction="row" spacing={1}>
       <span>Ends in</span>
       <SquaredChip
-        label={<Typography variant="subtitle1">{timeLeft}</Typography>}
+        label={
+          <Typography component="span" variant="subtitle1">
+            {timeLeft}
+          </Typography>
+        }
         color="warning"
       />
     </Stack>

--- a/packages/client/src/pages/GatewaysPage/AutoExtension.tsx
+++ b/packages/client/src/pages/GatewaysPage/AutoExtension.tsx
@@ -39,7 +39,11 @@ export function AutoExtension({ value, disabled }: { value?: boolean; disabled?:
           disabled={disabled}
           checked={value}
           control={<Switch onChange={handleChange} />}
-          label={<Typography variant="body2">Auto Extension</Typography>}
+          label={
+            <Typography component="span" variant="body2">
+              Auto Extension
+            </Typography>
+          }
           labelPlacement="start"
         />
       </FormGroup>

--- a/packages/client/src/pages/GatewaysPage/GatewaysPage.tsx
+++ b/packages/client/src/pages/GatewaysPage/GatewaysPage.tsx
@@ -205,9 +205,7 @@ export function MyGateways() {
               </TableRow>
             ))
           ) : isLoading ? null : (
-            <NoItems>
-              <Typography>No portal registered yet</Typography>
-            </NoItems>
+            <NoItems message="No portal registered yet" />
           )}
         </TableBody>
       </DashboardTable>

--- a/packages/mock-stack/src/autoDistribute.ts
+++ b/packages/mock-stack/src/autoDistribute.ts
@@ -64,8 +64,7 @@ export function startAutoDistributor(opts: AutoDistributorOpts): AutoDistributor
   const pollMs = opts.pollIntervalMs ?? 6_000;
 
   let workerRegAbi: Abi | undefined;
-  const getWorkerRegAbi = (): Abi =>
-    (workerRegAbi ??= networkArtifact('WorkerRegistration').abi);
+  const getWorkerRegAbi = (): Abi => (workerRegAbi ??= networkArtifact('WorkerRegistration').abi);
 
   let stopped = false;
 

--- a/packages/mock-stack/src/indexer/operations/network.ts
+++ b/packages/mock-stack/src/indexer/operations/network.ts
@@ -220,7 +220,11 @@ export function registerNetworkResolvers(deps: NetworkResolverDeps): void {
     const [epochNumber, nextEpochBlock, workerEpochLength] = (await Promise.all([
       deps.client.readContract({ abi: networkAbi, address: addr, functionName: 'epochNumber' }),
       deps.client.readContract({ abi: networkAbi, address: addr, functionName: 'nextEpoch' }),
-      deps.client.readContract({ abi: networkAbi, address: addr, functionName: 'workerEpochLength' }),
+      deps.client.readContract({
+        abi: networkAbi,
+        address: addr,
+        functionName: 'workerEpochLength',
+      }),
     ])) as [bigint, bigint, bigint];
 
     const head = deps.getLastBlock();

--- a/packages/mock-stack/src/rewards.ts
+++ b/packages/mock-stack/src/rewards.ts
@@ -15,13 +15,7 @@
  * after preseeding" property: same cadence, same range invariants, same
  * code path; only the reward payload differs.
  */
-import {
-  type Address,
-  type PublicClient,
-  type WalletClient,
-  createPublicClient,
-  http,
-} from 'viem';
+import { type Address, type PublicClient, type WalletClient, createPublicClient, http } from 'viem';
 
 import { networkArtifact } from './artifacts';
 import { REWARD_BLOCKS_PER_COMMIT } from './config';
@@ -63,9 +57,7 @@ export interface CommitChunksResult {
  * the contract's current `lastBlockRewarded` and `upperBound`, emitting
  * one `commit()` per window.
  */
-export async function commitRewardChunks(
-  opts: CommitChunksOpts,
-): Promise<CommitChunksResult> {
+export async function commitRewardChunks(opts: CommitChunksOpts): Promise<CommitChunksResult> {
   const chain = chainFor(opts.chainId);
   const publicClient: PublicClient = createPublicClient({
     chain,
@@ -82,8 +74,7 @@ export async function commitRewardChunks(
     functionName: 'lastBlockRewarded',
   })) as bigint;
 
-  const upperBound =
-    opts.upperBound ?? (await publicClient.getBlockNumber()) - 1n;
+  const upperBound = opts.upperBound ?? (await publicClient.getBlockNumber()) - 1n;
   const chunk = REWARD_BLOCKS_PER_COMMIT;
   const max = opts.maxChunks ?? Number.MAX_SAFE_INTEGER;
 
@@ -95,13 +86,7 @@ export async function commitRewardChunks(
       abi,
       address: opts.rewardDistribution,
       functionName: 'commit',
-      args: [
-        fromBlock,
-        toBlock,
-        opts.recipients,
-        opts.workerRewards,
-        opts.stakerRewards,
-      ],
+      args: [fromBlock, toBlock, opts.recipients, opts.workerRewards, opts.stakerRewards],
       account: opts.wallet.account!,
       chain: opts.wallet.chain,
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `validateDOMNesting` browser console errors that appeared when opening certain pages and modals. React logs these when HTML spec rules are violated (e.g. block elements inside inline/heading elements, `<p>` nested inside `<p>`, block elements inside `<span>`/`<label>`).

### Root causes fixed

| File | Problem | Fix |
|---|---|---|
| `NetworkLayout/PageTitle.tsx` | `<Box>` (div) inside `<Typography variant="h4">` (h4) | Remove Box; apply `color` prop directly on Typography |
| `NetworkLayout/NetworkPageTitle.tsx` | layout `<div>` with BackButton/Box/endAdornment inside `<Typography variant="h1">` (h1) | Move the div outside; Typography wraps only the title text |
| `DashboardPage/Summary.tsx` — `ColumnLabel` | `<Typography variant="h4">` (h4) used as a container for arbitrary block children (Stack, Box, HelpTooltip) in `GatewaysPage` | Add `component="div"` so it renders a `<div>` |
| `DashboardPage/Summary.tsx` — `SquaredChip` labels | `<Typography variant="subtitle1">` (p) passed as Chip label, rendered inside `<span>` | Add `component="span"` |
| `components/Table/NoItems.tsx` | Wraps children in `<Typography variant="body1">` (p); callers passing `<Typography>` or other nodes caused nested `<p>` | Render children directly; keep Typography only for the default message text |
| `components/Table/PaginatedTable.tsx` | Passed `<Typography>` inside `<NoItems>` causing nested `<p>` | Use `message` prop instead |
| `GatewaysPage/GatewaysPage.tsx` | Same nested Typography in NoItems | Use `message` prop instead |
| `GatewaysPage/AutoExtension.tsx` | `<Typography variant="body2">` (p) inside `<FormControlLabel label={…}>` (label); block element inside phrasing context | Add `component="span"` |
| `DashboardPage/DashboardPage.tsx` | `<Stack>` (div) inside MUI `<Tab label={…}>` (span) | Add `component="span"` to Stack |
| `components/PageTabs/PageTabs.tsx` | `<Box>` (div) inside MUI `<Tab label={…}>` (span) | Add `component="span"` to Box |

### Testing

- ✅ `pnpm lint` — no new errors
- ✅ `pnpm tsc` — no type errors
- ✅ `pnpm --filter @subsquid/client test:unit` — 6/6 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee4a0e08-e6fc-43de-b1b3-c62acc7cc1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee4a0e08-e6fc-43de-b1b3-c62acc7cc1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

