### PR TITLE
docs: factual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,41 @@
-# SQD Network UI
+# SQD Network App
+
+Web application for the SQD Network: a frontend for viewing and managing network participants (workers, gateways, portal pools, and delegations) along with the SQD token assets they involve.
+
+## What it is
+
+This is the web UI for [SQD Network](https://sqd.dev/network), the decentralized data lake behind SQD. It is a pnpm + Turborepo monorepo with three packages:
+
+- `packages/client` — React 19 single-page app (Vite, MUI v7, RainbowKit + wagmi v2). Wallet connectivity targets Arbitrum One (mainnet) or Arbitrum Sepolia (the `tethys` testnet).
+- `packages/server` — Node.js tRPC API server. The client talks only to this server, which aggregates data from the SQD Squid GraphQL APIs (indexed onchain state) and direct Arbitrum RPC calls (via viem).
+- `packages/common` — shared contract ABIs and addresses used by both client and server.
+
+The client renders pages for the dashboard, workers, gateways, portal pools, delegations, assets, and buy-back.
 
 ## Prerequisites
 
-- **Node.js 22**
-- **pnpm 9**: `npm install -g pnpm`
+- Node.js 22
+- pnpm 9: `npm install -g pnpm`
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and fill in the required values
+1. Copy `.env.example` to `.env` and fill in the required values.
 2. `pnpm install`
+
+### Environment variables
+
+See `.env.example` for the full list. Key variables:
+
+| Variable | Purpose |
+|---|---|
+| `NETWORK` | `mainnet` or `tethys` (testnet): selects chain and API endpoints |
+| `RPC_URL` | Arbitrum RPC endpoint |
+| `WALLET_CONNECT_PROJECT_ID` | WalletConnect project ID |
+| `MAINNET_WORKERS_SQUID_API_URL` / `TESTNET_WORKERS_SQUID_API_URL` | Workers Squid GraphQL endpoint |
+| `MAINNET_GATEWAYS_SQUID_API_URL` / `TESTNET_GATEWAYS_SQUID_API_URL` | Gateways Squid GraphQL endpoint |
+| `MAINNET_TOKEN_SQUID_API_URL` / `TESTNET_TOKEN_SQUID_API_URL` | Token Squid GraphQL endpoint |
+| `SERVER_PORT` | Port for the tRPC server (default: `3001`) |
+| `SENTRY_DSN` | Sentry DSN (optional) |
 
 ## Development
 
@@ -31,3 +58,8 @@ pnpm lint       # lint all packages with Biome
 pnpm tsc        # type-check all packages
 pnpm codegen    # regenerate GraphQL + wagmi types
 ```
+
+## Documentation
+
+- SQD Network: https://docs.sqd.dev/en/network
+- SQD docs: https://docs.sqd.dev

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Web application for the SQD Network: a frontend for viewing and managing network
 
 This is the web UI for [SQD Network](https://sqd.dev/network), the decentralized data lake behind SQD. It is a pnpm + Turborepo monorepo with three packages:
 
-- `packages/client` — React 19 single-page app (Vite, MUI v7, RainbowKit + wagmi v2). Wallet connectivity targets Arbitrum One (mainnet) or Arbitrum Sepolia (the `tethys` testnet).
-- `packages/server` — Node.js tRPC API server. The client talks only to this server, which aggregates data from the SQD Squid GraphQL APIs (indexed onchain state) and direct Arbitrum RPC calls (via viem).
-- `packages/common` — shared contract ABIs and addresses used by both client and server.
+- `packages/client`: React 19 single-page app (Vite, MUI v7, RainbowKit + wagmi v2). Wallet connectivity targets Arbitrum One (mainnet) or Arbitrum Sepolia (the `tethys` testnet).
+- `packages/server`: Node.js tRPC API server. The client talks only to this server, which aggregates data from the SQD Squid GraphQL APIs (indexed onchain state) and direct Arbitrum RPC calls (via viem).
+- `packages/common`: shared contract ABIs and addresses used by both client and server.
 
 The client renders pages for the dashboard, workers, gateways, portal pools, delegations, assets, and buy-back.
 


### PR DESCRIPTION
Expands the README with a factual project overview while preserving the existing setup/build/scripts sections.

## What I confirmed (from repo files)

- **Purpose** (`packages/client/index.html` title "SQD Network App", `AGENTS.md`, `packages/client/src/pages/`): web UI for the SQD Network. Pages: Dashboard, Workers, Gateways, Portal Pools, Delegations, Assets, BuyBack.
- **Monorepo structure** (`pnpm-workspace.yaml`, `turbo.json`, `packages/`): three packages — `client` (React 19 SPA: Vite + MUI v7 + RainbowKit/wagmi v2, per `packages/client/package.json`), `server` (Node.js tRPC API using viem + GraphQL, per `packages/server/package.json`), and `common` (shared contract ABIs/addresses, per `packages/common/src/abi/` and `addresses.ts`).
- **Architecture** (`AGENTS.md` Architecture Notes): client talks to the server via tRPC; server aggregates Squid GraphQL APIs + direct Arbitrum RPC. Wallet targets Arbitrum One (mainnet) / Arbitrum Sepolia (tethys).
- **Env vars** (`.env.example`): `NETWORK`, `RPC_URL`, `WALLET_CONNECT_PROJECT_ID`, `*_WORKERS/GATEWAYS/TOKEN_SQUID_API_URL`, `SERVER_PORT`, `SENTRY_DSN`. Documented the real names from `.env.example` (the prior README listed differently-named vars).
- **Scripts/ports** (`package.json` root + `packages/client/package.json`): `pnpm dev` (client 3005 / server 3001), `build`, `build:client`, `build:server`, `lint` (Biome), `tsc`, `codegen`. Kept as-is, all verified against package scripts.

## Links verified 200

- https://docs.sqd.dev
- https://docs.sqd.dev/en/network
- https://sqd.dev/network

No code or config touched, README only.